### PR TITLE
Delay gnocchi client creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gnocchiclient>=3.1.0
+gnocchiclient>=3.3.0
 keystoneauth1


### PR DESCRIPTION
During the config phase, the python threading system is not yet
initialized. Making some lib not behaving correctly.

This moves the gnocchiclient setup to the init phase.