### PR TITLE
Keep auth_url consistent in __init__.py

### DIFF
--- a/collectd_gnocchi/__init__.py
+++ b/collectd_gnocchi/__init__.py
@@ -50,10 +50,10 @@ class Gnocchi(object):
     def init(self):
         auth_mode = self.conf.get('auth_mode', 'basic').lower()
         if auth_mode == 'keystone':
-            authurl = self.conf.get("authurl")
-            if authurl is None:
+            auth_url = self.conf.get("auth_url")
+            if auth_url is None:
                 raise RuntimeError(
-                    "Please specify `authurl` for Keystone auth_mode")
+                    "Please specify `auth_url` for Keystone auth_mode")
 
             kwargs = {}
 


### PR DESCRIPTION
Example conf has auth_url but it's actually looking for self.conf.get("authurl") 

debug output:
 [error] File "/var/lib/kolla/venv/lib/python2.7/site-packages/collectd_gnocchi/__init__.py", line 56, in init
    "Please specify `authurl` for Keystone auth_mode")

Example conf can be modified accordingly (authurl) but keeping it consistent (auth_url)