### PR TITLE
Add support for old option authurl instead of auth_url

### DIFF
--- a/collectd_gnocchi/__init__.py
+++ b/collectd_gnocchi/__init__.py
@@ -50,7 +50,7 @@ class Gnocchi(object):
     def init(self):
         auth_mode = self.conf.get('auth_mode', 'basic').lower()
         if auth_mode == 'keystone':
-            auth_url = self.conf.get("auth_url")
+            auth_url = self.conf.get("auth_url", self.conf.get("authurl"))
             if auth_url is None:
                 raise RuntimeError(
                     "Please specify `auth_url` for Keystone auth_mode")


### PR DESCRIPTION
This avoids breaking compatibility with existing working deployments.